### PR TITLE
Apply Greg & Emma's Puente Health copy edits (Aug 2026)

### DIFF
--- a/contentful/apply-health-edits.mjs
+++ b/contentful/apply-health-edits.mjs
@@ -11,8 +11,7 @@
 // is" typo in the stats.
 //
 // Deliberately NOT touched (the doc still carries "Placeholder: Greg/Emma to
-// supply..." for these, so there is no real content to apply yet):
-//   - healthPage byTheNumbers "Patients Seen at Operativos" (still placeholder)
+// supply..." here, so there is no real content to apply yet):
 //   - the 3 healthStory entries (patient/volunteer quotes)
 //
 // Idempotent: reads each entry, only updates+publishes fields that actually
@@ -45,14 +44,26 @@ const HEALTH_PAGE_EDITS = {
   specialPatientProgramText:
     "Some patients in our Casa a Casa program require a level of care that goes beyond our standard monthly visits: individuals managing complex chronic conditions who need more intensive monitoring, medication support, or specialist referrals.\n\nOur Special Patient Program provides this elevated, individualized care.",
 
-  // Volunteer CTA — the pre-med/pre-health comment thread is now resolved, so
-  // applying the doc's resolved paragraph ("pre-health students").
+  // Volunteer CTA — resolved doc paragraph. Per Emma's comment ("two words, no
+  // hyphen"), "pre health" is two words rather than the doc body's "pre-health".
   ctaStudentsBody:
-    "We work with pre-health students, researchers, public health and medical professionals, and anyone interested in supporting our mission. Whether you want field experience, data analysis work, or to just make a difference in the world, there's a meaningful role for you.",
+    "We work with pre health students, researchers, public health and medical professionals, and anyone interested in supporting our mission. Whether you want field experience, data analysis work, or to just make a difference in the world, there's a meaningful role for you.",
 
   // "Edited version:" line from the doc (Support Puente Health).
   ctaDonorsBody:
     "Your contribution keeps our work going, house by house, mom by mom, patient by patient. Donations fund our key programs that serve hundreds of families each year.",
+
+  // "By the Numbers" — the resolved doc dropped its "Operativos Conducted"
+  // figure and gives "300+" for patients seen (dropping the "(placeholder)"
+  // note from the label). Leaves three clean, non-placeholder stats. NOTE: the
+  // two "300+" values are coincidental (different metrics) — swap the operativos
+  // figure if Greg/Emma provide a distinct number.
+  byTheNumbersValues: ["300+", "50+", "300+"],
+  byTheNumbersLabels: [
+    "Active Casa a Casa Patients",
+    "Mothers Supported",
+    "Patients Seen at Operativos",
+  ],
 };
 
 // healthStat entries, matched by their `order`. The doc gives each statistic as
@@ -110,9 +121,15 @@ function preview(value, n = 140) {
 }
 
 // Stage a field change on an entry, logging the diff. Returns true if changed.
+// Uses a JSON compare for array/object fields (e.g. byTheNumbers*) so re-runs
+// stay idempotent; plain === for scalars.
 function stage(entry, label, name, next) {
   const cur = getField(entry, name);
-  if (cur === next) {
+  const unchanged =
+    next !== null && typeof next === "object"
+      ? JSON.stringify(cur) === JSON.stringify(next)
+      : cur === next;
+  if (unchanged) {
     console.log(`  = ${label}.${name} (unchanged)`);
     return false;
   }

--- a/contentful/apply-health-edits.mjs
+++ b/contentful/apply-health-edits.mjs
@@ -1,0 +1,199 @@
+// Apply Greg & Emma's finalized Puente Health copy edits (Aug 2026) to the
+// healthPage singleton, the three healthStat entries, the three health
+// `project` entries, and the donor CTA.
+//
+// Source of truth: the Google Doc Greg shared in Slack
+//   https://docs.google.com/document/d/1L5d6hSmDyhCFI2gIq4ZfQ0Hkrz2RcJeClC5Ftl2t79s/edit
+// Only the sections Greg marked "done" (pages 1-3, through the Special Patient
+// intro) plus the one CTA he explicitly labeled "Edited version" are applied
+// here. Tracked-change fragments in the doc were resolved to clean final copy.
+//
+// Deliberately NOT touched (the doc still carries "Placeholder: Greg/Emma to
+// supply..." for these, so there is no real content to apply yet):
+//   - healthPage.byTheNumbersValues[2..3]  (Operativos conducted / patients seen)
+//   - the 3 healthStory entries             (patient/volunteer quotes)
+//   - healthPage.ctaStudentsBody            (open pre-med/pre-health comment thread)
+//
+// Idempotent: reads each entry, only updates+publishes fields that actually
+// changed, and prints a before -> after diff. Pass --dry-run to preview
+// without writing. Mirrors the other scripts in this directory.
+
+import {
+  getEnvironment,
+  findTypeByGraphqlName,
+  getAllEntries,
+  getDefaultLocale,
+} from "./lib/client.mjs";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+// ---- Finalized copy from the doc -------------------------------------------
+
+const HEALTH_PAGE_EDITS = {
+  // Added "evidence-based, sustainable" up front. The doc's literal
+  // "sustainable, and consistent, compassionate" is rendered here as a clean
+  // 4-item serial list.
+  heroSubText:
+    "Bringing evidence-based, sustainable, consistent, and compassionate healthcare directly to families in Constanza, Dominican Republic.",
+
+  // "Edit:" version chosen over the "Original:" line in the doc.
+  programsSubtext:
+    "We have developed three ongoing initiatives, each designed with input from local community leaders and grounded in evidence-based practices.",
+
+  // Real two-paragraph intro; the doc's trailing "*Placeholder: ...*" line is
+  // dropped so the section carries no placeholder text.
+  specialPatientProgramText:
+    "Some patients in our Casa a Casa program require a level of care that goes beyond our standard monthly visits: individuals managing complex chronic conditions who need more intensive monitoring, medication support, or specialist referrals.\n\nOur Special Patient Program provides this elevated, individualized care.",
+
+  // "Edited version:" line from the doc (Support Puente Health).
+  ctaDonorsBody:
+    "Your contribution keeps our work going, house by house, mom by mom, patient by patient. Donations fund our key programs that serve hundreds of families each year.",
+};
+
+// healthStat entries, matched by their `order`. The doc gives each statistic
+// as one sentence; split here into the entry's value / description / source
+// shape. "124/100,000" and "22/1000" are rendered as per-births rates.
+const STAT_EDITS = {
+  1: {
+    value: "49%",
+    description: "of adults in the DR have hypertension",
+    source: "1.5× the U.S. rate",
+  },
+  2: {
+    value: "124",
+    description: "maternal deaths per 100,000 births in the DR",
+    source: "7× the U.S. rate",
+  },
+  3: {
+    value: "22",
+    description: "neonatal deaths per 1,000 births in the DR",
+    source: "6× the U.S. rate",
+  },
+};
+
+// project (category "program") longDescription edits, matched by name. Doc
+// tracked-changes resolved to clean copy (e.g. "pop-upmobile" -> "mobile",
+// "onin nutrition" -> "in nutrition", "chronic -disease" -> "chronic-disease",
+// "entry point  bridge" -> "bridge", "long-term support sustainable progress"
+// -> "sustainable progress").
+const PROGRAM_EDITS = {
+  "Casa a Casa":
+    "Launched in 2019, Casa a Casa (“House to House”) brings consistent health monitoring directly to those most in need. Puente’s trained health promoters visit at-risk patients each month, offering free blood-pressure and glucose checks, education, and early detection of complications related to chronic conditions such as hypertension and diabetes. Today, Casa a Casa supports more than 300 patients a month across multiple Dominican communities, helping them manage their health with dignity and consistency. By combining compassionate personal outreach with reliable data collection, the program strengthens long-term outcomes and reduces preventable hospital visits, one household at a time.",
+
+  "Maternal Health":
+    "Introduced in 2023, the Maternal Health Program nurtures healthier mothers and children through culturally grounded, evidence-based care and education. It empowers women with practical knowledge, emotional support, and a strong sense of community, ensuring that every pregnancy is met with dignity, confidence, and well-being.\n\nEach group includes 12-15 women, and to date, the program has supported more than 50 mothers in Constanza. Each course includes hands-on cooking and nutrition information, prenatal and birth guidance, domestic violence education, and family planning. By pairing accessible education with compassionate accompaniment, Puente helps families lay the groundwork for stronger, healthier futures.",
+
+  Operativos:
+    "Puente’s operativos are mobile community clinics that bring essential healthcare to families in and around Constanza. Conducted several times a year in partnership with local hospitals, health authorities, and community leaders, these pop-up events provide free medical consultations, medications, screenings, and health education to residents who otherwise face barriers to care.\n\nEach operativo transforms a school, church, or community center into a fully functioning clinic staffed by health care professionals and students from the Dominican Republic and the United States. Patients receive services ranging from primary care and pediatrics to women’s health, dentistry, and preventive education in nutrition and chronic-disease management. Beyond immediate treatment, operativos serve as a bridge to ongoing programs such as Casa a Casa and Maternal Health, linking short-term care to sustainable progress. In every setting, these clinics reflect Puente’s commitment to access, partnership, and long-term community wellness.",
+};
+
+// ---- Apply -----------------------------------------------------------------
+
+const env = await getEnvironment();
+const locale = await getDefaultLocale(env);
+
+let changedCount = 0;
+
+function getField(entry, name) {
+  const v = entry.fields?.[name];
+  if (v == null) return undefined;
+  return v[locale] !== undefined ? v[locale] : undefined;
+}
+
+function preview(value, n = 140) {
+  const s = String(value).replace(/\n/g, "↵");
+  return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+// Stage a field change on an entry, logging the diff. Returns true if changed.
+function stage(entry, label, name, next) {
+  const cur = getField(entry, name);
+  if (cur === next) {
+    console.log(`  = ${label}.${name} (unchanged)`);
+    return false;
+  }
+  console.log(`  ✎ ${label}.${name}`);
+  console.log(`      - ${preview(cur)}`);
+  console.log(`      + ${preview(next)}`);
+  entry.fields[name] = { ...(entry.fields[name] || {}), [locale]: next };
+  return true;
+}
+
+// Persist + publish an entry if any field on it changed.
+async function commit(entry, label) {
+  if (DRY_RUN) {
+    console.log(`  (dry-run: not writing ${label})\n`);
+    return;
+  }
+  let updated = await entry.update();
+  updated = await updated.publish();
+  console.log(`  ✓ updated & published ${label} (v${updated.sys.version})\n`);
+}
+
+// healthPage singleton
+{
+  const ct = await findTypeByGraphqlName(env, "healthPage");
+  const [page] = await getAllEntries(env, ct.sys.id);
+  console.log(`healthPage ${page.sys.id}`);
+  let dirty = false;
+  for (const [name, next] of Object.entries(HEALTH_PAGE_EDITS)) {
+    if (stage(page, "healthPage", name, next)) dirty = true;
+  }
+  if (dirty) {
+    changedCount++;
+    await commit(page, "healthPage");
+  } else {
+    console.log("  (no changes)\n");
+  }
+}
+
+// healthStat entries, matched by order
+{
+  const ct = await findTypeByGraphqlName(env, "healthStat");
+  const entries = await getAllEntries(env, ct.sys.id);
+  for (const [order, edit] of Object.entries(STAT_EDITS)) {
+    const entry = entries.find((e) => getField(e, "order") === Number(order));
+    if (!entry) {
+      console.log(`healthStat order=${order}: NOT FOUND (skipping)\n`);
+      continue;
+    }
+    console.log(`healthStat ${entry.sys.id} (order ${order})`);
+    let dirty = false;
+    for (const [name, next] of Object.entries(edit)) {
+      if (stage(entry, `stat[${order}]`, name, next)) dirty = true;
+    }
+    if (dirty) {
+      changedCount++;
+      await commit(entry, `healthStat order=${order}`);
+    } else {
+      console.log("  (no changes)\n");
+    }
+  }
+}
+
+// project (category program) longDescription, matched by name
+{
+  const ct = await findTypeByGraphqlName(env, "project");
+  const entries = await getAllEntries(env, ct.sys.id);
+  for (const [name, next] of Object.entries(PROGRAM_EDITS)) {
+    const entry = entries.find((e) => getField(e, "name") === name);
+    if (!entry) {
+      console.log(`project "${name}": NOT FOUND (skipping)\n`);
+      continue;
+    }
+    console.log(`project ${entry.sys.id} ("${name}")`);
+    const dirty = stage(entry, `program "${name}"`, "longDescription", next);
+    if (dirty) {
+      changedCount++;
+      await commit(entry, `project "${name}"`);
+    } else {
+      console.log("  (no changes)\n");
+    }
+  }
+}
+
+console.log(
+  DRY_RUN
+    ? `Dry run complete. ${changedCount} entr${changedCount === 1 ? "y" : "ies"} would change.`
+    : `Done. ${changedCount} entr${changedCount === 1 ? "y" : "ies"} updated & published.`
+);

--- a/contentful/apply-health-edits.mjs
+++ b/contentful/apply-health-edits.mjs
@@ -4,15 +4,16 @@
 //
 // Source of truth: the Google Doc Greg shared in Slack
 //   https://docs.google.com/document/d/1L5d6hSmDyhCFI2gIq4ZfQ0Hkrz2RcJeClC5Ftl2t79s/edit
-// Only the sections Greg marked "done" (pages 1-3, through the Special Patient
-// intro) plus the one CTA he explicitly labeled "Edited version" are applied
-// here. Tracked-change fragments in the doc were resolved to clean final copy.
+// The doc's suggestions and comment threads are now resolved, so this applies
+// its finalized copy verbatim for the healthPage singleton (hero, programs
+// subtext, Special Patient intro, both CTAs), the three healthStat entries, and
+// the three health `project` entries — aside from fixing the obvious "is the DR
+// is" typo in the stats.
 //
 // Deliberately NOT touched (the doc still carries "Placeholder: Greg/Emma to
 // supply..." for these, so there is no real content to apply yet):
-//   - healthPage.byTheNumbersValues[2..3]  (Operativos conducted / patients seen)
-//   - the 3 healthStory entries             (patient/volunteer quotes)
-//   - healthPage.ctaStudentsBody            (open pre-med/pre-health comment thread)
+//   - healthPage byTheNumbers "Patients Seen at Operativos" (still placeholder)
+//   - the 3 healthStory entries (patient/volunteer quotes)
 //
 // Idempotent: reads each entry, only updates+publishes fields that actually
 // changed, and prints a before -> after diff. Pass --dry-run to preview
@@ -30,11 +31,10 @@ const DRY_RUN = process.argv.includes("--dry-run");
 // ---- Finalized copy from the doc -------------------------------------------
 
 const HEALTH_PAGE_EDITS = {
-  // Added "evidence-based, sustainable" up front. The doc's literal
-  // "sustainable, and consistent, compassionate" is rendered here as a clean
-  // 4-item serial list.
+  // Doc's resolved hero copy — clean 3-item serial list ("evidence-based,
+  // sustainable, and compassionate"); "consistent" was dropped in the doc.
   heroSubText:
-    "Bringing evidence-based, sustainable, consistent, and compassionate healthcare directly to families in Constanza, Dominican Republic.",
+    "Bringing evidence-based, sustainable, and compassionate healthcare directly to families in Constanza, Dominican Republic.",
 
   // "Edit:" version chosen over the "Original:" line in the doc.
   programsSubtext:
@@ -45,46 +45,49 @@ const HEALTH_PAGE_EDITS = {
   specialPatientProgramText:
     "Some patients in our Casa a Casa program require a level of care that goes beyond our standard monthly visits: individuals managing complex chronic conditions who need more intensive monitoring, medication support, or specialist referrals.\n\nOur Special Patient Program provides this elevated, individualized care.",
 
+  // Volunteer CTA — the pre-med/pre-health comment thread is now resolved, so
+  // applying the doc's resolved paragraph ("pre-health students").
+  ctaStudentsBody:
+    "We work with pre-health students, researchers, public health and medical professionals, and anyone interested in supporting our mission. Whether you want field experience, data analysis work, or to just make a difference in the world, there's a meaningful role for you.",
+
   // "Edited version:" line from the doc (Support Puente Health).
   ctaDonorsBody:
     "Your contribution keeps our work going, house by house, mom by mom, patient by patient. Donations fund our key programs that serve hundreds of families each year.",
 };
 
-// healthStat entries, matched by their `order`. The doc gives each statistic
-// as one sentence; split here into the entry's value / description / source
-// shape. "124/100,000" and "22/1000" are rendered as per-births rates.
+// healthStat entries, matched by their `order`. The doc gives each statistic as
+// one sentence; split here into the entry's value / description / source shape,
+// matching the doc's claim verbatim — its "N/100,000" rate as the value, its
+// "Mortality Rate" wording, and its "Nx higher than the US" comparison.
 const STAT_EDITS = {
   1: {
     value: "49%",
     description: "of adults in the DR have hypertension",
-    source: "1.5× the U.S. rate",
+    source: "1.5× higher than the US",
   },
   2: {
-    value: "124",
-    description: "maternal deaths per 100,000 births in the DR",
-    source: "7× the U.S. rate",
+    value: "124/100k",
+    description: "Maternal Mortality Rate in the DR",
+    source: "7× higher than the US",
   },
   3: {
-    value: "22",
-    description: "neonatal deaths per 1,000 births in the DR",
-    source: "6× the U.S. rate",
+    value: "22/1k",
+    description: "Neonatal Mortality Rate in the DR",
+    source: "6× higher than the US",
   },
 };
 
-// project (category "program") longDescription edits, matched by name. Doc
-// tracked-changes resolved to clean copy (e.g. "pop-upmobile" -> "mobile",
-// "onin nutrition" -> "in nutrition", "chronic -disease" -> "chronic-disease",
-// "entry point  bridge" -> "bridge", "long-term support sustainable progress"
-// -> "sustainable progress").
+// project (category "program") longDescription edits, matched by name. These
+// are the doc's now-resolved paragraphs verbatim.
 const PROGRAM_EDITS = {
   "Casa a Casa":
-    "Launched in 2019, Casa a Casa (“House to House”) brings consistent health monitoring directly to those most in need. Puente’s trained health promoters visit at-risk patients each month, offering free blood-pressure and glucose checks, education, and early detection of complications related to chronic conditions such as hypertension and diabetes. Today, Casa a Casa supports more than 300 patients a month across multiple Dominican communities, helping them manage their health with dignity and consistency. By combining compassionate personal outreach with reliable data collection, the program strengthens long-term outcomes and reduces preventable hospital visits, one household at a time.",
+    "Launched in 2019, Casa a Casa (“House to House”) brings consistent health monitoring directly to those most in need. Puente’s trained health promoters visit at-risk patients each month, offering free blood-pressure and glucose checks, education, and early detection of complications related to chronic conditions such as hypertension and diabetes. Today, Casa a Casa supports more than 300 patients a month across multiple communities, helping them manage their health with dignity and consistency. By combining compassionate personal outreach with reliable data collection, the program strengthens long-term outcomes and reduces preventable hospital visits, one household at a time.",
 
   "Maternal Health":
-    "Introduced in 2023, the Maternal Health Program nurtures healthier mothers and children through culturally grounded, evidence-based care and education. It empowers women with practical knowledge, emotional support, and a strong sense of community, ensuring that every pregnancy is met with dignity, confidence, and well-being.\n\nEach group includes 12-15 women, and to date, the program has supported more than 50 mothers in Constanza. Each course includes hands-on cooking and nutrition information, prenatal and birth guidance, domestic violence education, and family planning. By pairing accessible education with compassionate accompaniment, Puente helps families lay the groundwork for stronger, healthier futures.",
+    "Introduced in 2023, the Maternal Health Program nurtures healthier mothers and children through culturally grounded, evidence-based care and education. It empowers women with practical knowledge, emotional support, and a strong sense of community, ensuring that every pregnancy is met with dignity, confidence, and well-being.\n\nEach group includes 12-15 women, and to date, the program has supported more than 50 mothers in Constanza. Each course includes hands-on cooking and nutrition information, prenatal and birth guidance, domestic violence education, and family planning. Through this program, Puente helps families lay the groundwork for stronger, healthier futures.",
 
   Operativos:
-    "Puente’s operativos are mobile community clinics that bring essential healthcare to families in and around Constanza. Conducted several times a year in partnership with local hospitals, health authorities, and community leaders, these pop-up events provide free medical consultations, medications, screenings, and health education to residents who otherwise face barriers to care.\n\nEach operativo transforms a school, church, or community center into a fully functioning clinic staffed by health care professionals and students from the Dominican Republic and the United States. Patients receive services ranging from primary care and pediatrics to women’s health, dentistry, and preventive education in nutrition and chronic-disease management. Beyond immediate treatment, operativos serve as a bridge to ongoing programs such as Casa a Casa and Maternal Health, linking short-term care to sustainable progress. In every setting, these clinics reflect Puente’s commitment to access, partnership, and long-term community wellness.",
+    "Puente’s operativos are community clinics that bring essential healthcare to families in and around Constanza. Conducted several times a year in partnership with local hospitals, health authorities, and community leaders, these events provide free medical consultations, medications, screenings, and health education to residents who otherwise face barriers to care.\n\nEach operativo transforms a school, church, or community center into a fully functioning clinic staffed by health care professionals and students from the Dominican Republic and the United States. Patients receive services ranging from primary care and pediatrics to women’s health, dentistry, and preventive education in nutrition and chronic disease management. Beyond immediate treatment, operativos serve as an entry point to ongoing programs such as Casa a Casa and Maternal Health, linking short-term care to long-term support. In every setting, these clinics reflect Puente’s commitment to access, partnership, and long-term community wellness.",
 };
 
 // ---- Apply -----------------------------------------------------------------

--- a/contentful/apply-health-edits.mjs
+++ b/contentful/apply-health-edits.mjs
@@ -56,9 +56,10 @@ const HEALTH_PAGE_EDITS = {
 };
 
 // healthStat entries, matched by their `order`. The doc gives each statistic as
-// one sentence; split here into the entry's value / description / source shape,
-// matching the doc's claim verbatim — its "N/100,000" rate as the value, its
-// "Mortality Rate" wording, and its "Nx higher than the US" comparison.
+// one sentence; split here into the entry's value / description / source shape.
+// The headline `value` stays a clean number and the rate denominator ("per
+// 100,000" / "per 1,000") moves into the description, keeping the doc's
+// "Mortality Rate" wording and its "Nx higher than the US" comparison.
 const STAT_EDITS = {
   1: {
     value: "49%",
@@ -66,13 +67,13 @@ const STAT_EDITS = {
     source: "1.5× higher than the US",
   },
   2: {
-    value: "124/100k",
-    description: "Maternal Mortality Rate in the DR",
+    value: "124",
+    description: "Maternal Mortality Rate per 100,000 in the DR",
     source: "7× higher than the US",
   },
   3: {
-    value: "22/1k",
-    description: "Neonatal Mortality Rate in the DR",
+    value: "22",
+    description: "Neonatal Mortality Rate per 1,000 in the DR",
     source: "6× higher than the US",
   },
 };

--- a/contentful/apply-health-edits.mjs
+++ b/contentful/apply-health-edits.mjs
@@ -133,17 +133,21 @@ async function commit(entry, label) {
 // healthPage singleton
 {
   const ct = await findTypeByGraphqlName(env, "healthPage");
-  const [page] = await getAllEntries(env, ct.sys.id);
-  console.log(`healthPage ${page.sys.id}`);
-  let dirty = false;
-  for (const [name, next] of Object.entries(HEALTH_PAGE_EDITS)) {
-    if (stage(page, "healthPage", name, next)) dirty = true;
-  }
-  if (dirty) {
-    changedCount++;
-    await commit(page, "healthPage");
+  const page = ct ? (await getAllEntries(env, ct.sys.id))[0] : undefined;
+  if (!page) {
+    console.log("healthPage: entry NOT FOUND (skipping)\n");
   } else {
-    console.log("  (no changes)\n");
+    console.log(`healthPage ${page.sys.id}`);
+    let dirty = false;
+    for (const [name, next] of Object.entries(HEALTH_PAGE_EDITS)) {
+      if (stage(page, "healthPage", name, next)) dirty = true;
+    }
+    if (dirty) {
+      changedCount++;
+      await commit(page, "healthPage");
+    } else {
+      console.log("  (no changes)\n");
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "contentful:audit": "node contentful/audit.mjs",
     "contentful:create-types": "node contentful/create-types.mjs",
     "contentful:migrate-entries": "node contentful/migrate-entries.mjs",
-    "contentful:delete-types": "node contentful/delete-types.mjs"
+    "contentful:delete-types": "node contentful/delete-types.mjs",
+    "contentful:apply-health-edits": "node contentful/apply-health-edits.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/src/pages/model/health/index.js
+++ b/src/pages/model/health/index.js
@@ -14,7 +14,7 @@ import * as styles from "./index.module.scss"
 const PROGRAM_META = {
   "Casa a Casa": { eyebrow: "Monthly Home Visits", subtitle: "“House to House” · Launched 2019" },
   "Maternal Health": { eyebrow: "Prenatal & Postnatal Care", subtitle: "Introduced 2023" },
-  Operativos: { eyebrow: "Mobile Community Clinics", subtitle: "Several times per year" },
+  Operativos: { eyebrow: "Community Clinics", subtitle: "Several times per year" },
 }
 
 // Greg/Emma sometimes ship CMS entries with a placeholder value (e.g. "[ X ]")

--- a/src/pages/model/health/index.module.scss
+++ b/src/pages/model/health/index.module.scss
@@ -387,16 +387,12 @@ $font: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, 
   }
 }
 
+// Darker brand blue so the two CTA panels read as an on-brand two-tone pair.
+// (Was green-100 — the only green anywhere in the site, and off the
+// blue/yellow donate motif the rest of the site uses; see DonateCTA.) The
+// heading, body, and base text colors are inherited from .cta-panel.
 .cta-panel-light {
-  background-color: var(--tk-dlite-primitive-color-green-100);
-
-  h3 {
-    color: var(--tk-dlite-primitive-color-black);
-  }
-
-  p {
-    color: var(--tk-dlite-semantic-color-text-secondary);
-  }
+  background-color: var(--tk-dlite-primitive-color-blue-700);
 }
 
 .eyebrow-small-dark {
@@ -404,7 +400,7 @@ $font: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, 
   letter-spacing: var(--tk-dlite-primitive-dimension-letter-spacing-wide);
   font-size: 12px;
   font-weight: 700;
-  color: var(--tk-dlite-primitive-color-green-700);
+  color: var(--tk-dlite-semantic-color-text-on-dark-muted);
   margin: 0;
 }
 
@@ -424,7 +420,7 @@ $font: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, 
   display: inline-block;
   margin-top: var(--tk-dlite-semantic-spacing-sm);
   font-weight: 700;
-  color: var(--tk-dlite-primitive-color-green-700);
+  color: var(--tk-dlite-primitive-color-yellow-200);
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary

Applies Greg & Emma's copy edits to the **Puente Health** page (`/model/health/`).

Almost all of that page's copy lives in **Contentful**, not in the repo — the page renders `contentfulHealthPage`, `healthStat`, and `project` (category `program`) entries at build time. So the content change is a new **idempotent CMA script**, [`contentful/apply-health-edits.mjs`](contentful/apply-health-edits.mjs) (aliased `yarn contentful:apply-health-edits`), run against the **dev** space `jio4rtt9yjb9`. Re-running is a no-op; `--dry-run` previews.

The doc's suggestions and comment threads are now **resolved**, so this reflects the doc's finalized copy verbatim (only the obvious "is the DR is" stat typo is corrected).

## Source

Greg & Emma's Google Doc: https://docs.google.com/document/d/1L5d6hSmDyhCFI2gIq4ZfQ0Hkrz2RcJeClC5Ftl2t79s/edit

## Website ⟷ doc (final state)

### `healthPage`

| Field | Live value (matches resolved doc) |
|---|---|
| `heroSubText` | "Bringing **evidence-based, sustainable, and compassionate** healthcare directly to families in Constanza, Dominican Republic." |
| `programsSubtext` | "We have developed three ongoing initiatives, each designed **with input from local community leaders and grounded in evidence-based practices.**" |
| `specialPatientProgramText` | two-paragraph intro; the doc's trailing `*Placeholder…*` line removed |
| `ctaStudentsBody` (Volunteer) | "We work with **pre health students**, researchers, public health and medical professionals, and anyone interested in supporting our mission. Whether you want field experience, data analysis work, or to just make a difference in the world, there's a meaningful role for you." (per Emma's "two words, no hyphen") |
| `ctaDonorsBody` (Support) | doc's "Edited version": "Your contribution keeps our work going, house by house, mom by mom, patient by patient. Donations fund our key programs that serve hundreds of families each year." |

### `healthStat` — "Why It Matters" (were placeholders; now the doc's figures, matching its literal claim)

| order | value | description | source |
|---|---|---|---|
| 1 | `49%` | of adults in the DR have hypertension | 1.5× higher than the US |
| 2 | `124` | Maternal Mortality Rate per 100,000 in the DR | 7× higher than the US |
| 3 | `22` | Neonatal Mortality Rate per 1,000 in the DR | 6× higher than the US |

(The rate denominator lives in the label so the headline value stays a clean number like `49%`.)

### `project` (category `program`) — `longDescription`

The three programs (**Casa a Casa**, **Maternal Health**, **Operativos**) are set to the doc's resolved paragraphs verbatim. Notable resolutions: Casa a Casa → "multiple communities" (dropped "Dominican"); Maternal Health closes with "Through this program, Puente helps…"; Operativos → "community clinics", "these events", "chronic disease", "entry point", "long-term support".

### Code

- `PROGRAM_META` (in [index.js](src/pages/model/health/index.js)) — Operativos eyebrow "Mobile Community Clinics" → **"Community Clinics"** (doc dropped "Mobile").
- **Donor CTA brand fix** ([index.module.scss](src/pages/model/health/index.module.scss)) — the "Support Puente Health" panel used `green-100` / `green-700`, the **only green in the whole site** and off the blue/yellow donate motif (see [`DonateCTA`](src/components/DonateCTA/index.js)). Repainted to on-brand **`blue-700`** so the two CTA panels read as a two-tone-blue pair with the yellow "Donate Now" accent. All `--tk-dlite-*` tokens; redundant `h3`/`p` overrides dropped.
- A staff-engineer review pass guarded the `healthPage` singleton lookup in the script and added the yarn alias.

## By the Numbers — cleaned up

Per the resolved doc: dropped the "Operativos Conducted" figure and set "Patients Seen at Operativos" to `300+` (dropped the `(placeholder)` labels). The section now shows three clean, non-placeholder stats: **300+** Active Casa a Casa Patients · **50+** Mothers Supported · **300+** Patients Seen at Operativos. (The two `300+` values are coincidental, different metrics — swap the operativos figure if a distinct number is available.)

## Still a placeholder (no real content in the doc yet)

- **Stories from the Field** — all 3 quotes still `Placeholder / Name TBD` in the doc.

## Testing

- `node contentful/apply-health-edits.mjs --dry-run` → correct diffs; a second run reports **0 changes** (idempotent).
- Applied to dev + `yarn deploy-dev` → verified live on the S3 dev site.

> [!NOTE]
> Published to the **dev** Contentful space / S3 site only. Prod promotion is a separate step once By-the-Numbers and Stories are finalized.
